### PR TITLE
Fixed test not deleting doc dir and waiting for writing file

### DIFF
--- a/play-autodoc-core/src/test/scala/com/krrrr38/play/autodoc/AutodocHelpersSpec.scala
+++ b/play-autodoc-core/src/test/scala/com/krrrr38/play/autodoc/AutodocHelpersSpec.scala
@@ -26,8 +26,13 @@ class AutodocHelpersSpec extends FunSpec with Matchers with BeforeAndAfterAll wi
   }
 
   override protected def afterAll(): Unit = {
-    new File("doc").delete
+    delete(new File("doc"))
     System.setProperty("play.autodoc", "0")
+  }
+
+  def delete(file: File) {
+    if (file.isDirectory) Option(file.listFiles).map(_.toList).getOrElse(Nil).foreach(delete(_))
+    file.delete
   }
 
   describe("AutodocHelpers#autodoc") {
@@ -45,6 +50,7 @@ class AutodocHelpersSpec extends FunSpec with Matchers with BeforeAndAfterAll wi
         }
       ).route(req).get
       status(res) shouldBe OK
+      Thread.sleep(100)
 
       val doc = new File(documentPath)
       doc.exists() shouldBe true


### PR DESCRIPTION
I found two issues in the test:
1. Because `new File("doc").delete()` does not delete recursively, "doc" directory remains after running the test
2. You need to wait for writing the document file due to asynchronous  
   (Although I think Thread.sleep is not good, I cannot think of any good solution in this case...)
